### PR TITLE
Add gemini-plugin keyword to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "keywords": [
     "gemini",
+    "gemini-plugin",
     "saucelabs",
     "sauce",
     "connect",


### PR DESCRIPTION
We are going to add a link to the npm search by keyword "gemini-plugin"
right into gemini's README. Adding this keyoword to your plugin will help
other find it.
