### PR TITLE
Nullify _tunnel variable on tunnel close

### DIFF
--- a/lib/sauce.js
+++ b/lib/sauce.js
@@ -10,6 +10,7 @@ function Sauce() {
     console.log('Closing Sauce Connect.');
     if(_tunnel) {
       _tunnel.close(function() {
+        _tunnel = null;
         done();
       });
     } else {


### PR DESCRIPTION
In [gemini-gui](https://github.com/gemini-testing/gemini-gui) it is possible to re-run tests, but because closed tunnel is still defined it will throw `Error('Tunnel already opened.')` on next start

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saulis/gemini-sauce/8)

<!-- Reviewable:end -->
